### PR TITLE
Initial skeleton for widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ We recommend you add this right before the </head> tag.
 ```html
 <!-- Smoc Bot -->
 <script>
-    (function(d, w, c) {
-        w.SmocConversationTemplateId = 'YOUR-CONVERSATION-TEMPLATE-ID';
-        w.Color = "#ffeeed"
-        w.Shape = "round" // or "square"
-        w.Position = "bottom-left" // or "bottom-right"
-        w[c] = w[c] || function() {
-            (w[c].q = w[c].q || []).push(arguments);
-        };
+    (function(d, w) {
+        w.SmocConfig = {
+            conversationTemplate: 'YOUR-CONVERSATION-TEMPLATE-ID',
+            color: '#ffeeed',
+            shape: 'round', // or 'square'
+            position: 'bottom-left' // or 'bottom-right'
+        }
         var s = d.createElement('script');
         s.async = true;
-        s.src = 'https://unpkg.com/smocai/smoc-widget@1.0.0';
+        // s.src = 'https://unpkg.com/smocai/smoc-widget@1.0.0';
+        s.src = '/index.js';
         if (d.head) d.head.appendChild(s);
-    })(document, window, 'SmocWidget');
+    })(document, window);
 </script>
 ```
 

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,20 @@
             margin: 0;
         }
     </style>
-    <script src="/index.js"></script>
+    <script>
+        (function(d, w) {
+            w.SmocConfig = {
+                conversationTemplate: 'YOUR-CONVERSATION-TEMPLATE-ID',
+                color: '#ffeeed',
+                shape: 'round', // or 'square'
+                position: 'bottom-left' // or 'bottom-right'
+            }
+            var s = d.createElement('script');
+            s.async = true;
+            s.src = '/index.js';
+            if (d.head) d.head.appendChild(s);
+        })(document, window);
+    </script>
 </head>
 <body>
     <h1>Velkommen</h1>

--- a/src/SmocConfig.ts
+++ b/src/SmocConfig.ts
@@ -1,0 +1,6 @@
+export type SmocConfig = {
+  conversationTemplate: string,
+  color: string,
+  shape: string
+  position: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,10 @@
-alert('Smoc Widget 🚀')
+const container = document.createElement("div");
+container.style.position = "fixed";
+
+// Place the widget in the bottom right corner
+container.style.bottom = "30px";
+container.style.right = "30px";
+
+// TODO: Rather than just displaying the config, draw an icon in the bottom right corner
+container.innerHTML = JSON.stringify(window.SmocConfig);
+document.body.appendChild(container);

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -1,0 +1,5 @@
+import { SmocConfig } from "./SmocConfig";
+
+declare global {
+  interface Window { SmocConfig: SmocConfig; }
+}


### PR DESCRIPTION
This is a start for #1. I have simplified the installation `<script>` a little, and added some throwaway code that displays the config.

<img width="1146" alt="Screenshot 2024-02-05 at 14 20 00" src="https://github.com/SMOC-AI/smoc-widget/assets/1000/0db7cfef-b2cc-4e6c-b0c2-857fdf4a31e1">

Use this branch (`1-draw-icon`) as a starting point to implement #1.