### PR TITLE
This is a fix for size bug, and function to change border color with …

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,10 +30,10 @@
     <script>
         (function(d, w) {
             w.SmocConfig = {
-                url: 'https://example.com/',
-                color: '#0000FF',
+                url: 'https://go.smoc.ai/smocdemo/operator_390_channel_rx0k2rv0/operator_390_channel_rx0k2rv0_bot/new?draft_mode=true',
+                color: '#9f51bc',
                 shape: 'round', // or 'square'
-                position: 'bottom-left' // or 'bottom-right'
+                position: 'bottom-right' // or 'bottom-right'
             }
             var s = d.createElement('script');
             s.async = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ icon.addEventListener('click', () => {
     icon.style.display = 'block';
     borderWrapper.style.borderTop = 'none';
   } else {
+    const color = window.SmocConfig?.color || '#ffeeed';
     if (vw < 600) {
       iframe.style.width = '90vw';
       iframe.style.height = '80vh';
@@ -94,14 +95,14 @@ icon.addEventListener('click', () => {
       closeButton.style.top = '-30px';
       closeButton.style.right = '10px';
     } else {
-      iframe.style.width = '300px';
-      iframe.style.height = '400px';
+      iframe.style.width = '450px';
+      iframe.style.height = '500px';
       closeButton.style.top = '-30px';
       closeButton.style.right = '10px';
     }
     closeButton.style.display = 'block';
     icon.style.display = 'none';
-    borderWrapper.style.borderTop = '35px solid grey';
+    borderWrapper.style.borderTop = `35px solid ${color}`;
   }
 });
 
@@ -155,9 +156,8 @@ function changeIconShapeAndColor(): void {
 
 changeIconShapeAndColor();
 
-function applyPosition(): void {
+function applyPosition() {
   const position = window.SmocConfig?.position || 'bottom-right';
-
   switch (position) {
     case 'bottom-left':
       container.style.left = '64px';
@@ -173,8 +173,6 @@ function applyPosition(): void {
       break;
   }
 }
-
-applyPosition();
 
 document.body.appendChild(container);
 applyPosition();


### PR DESCRIPTION
I have fixed the size of the widget when opened on smaller phones and iPads, where the last positioning functionality caused a bug where the size did not change. I have also added functionality to change the border-top color to match the color of the SVG icon from the script tag.